### PR TITLE
Clean app images

### DIFF
--- a/cvm.sh
+++ b/cvm.sh
@@ -35,7 +35,7 @@
 #
 CURSOR_DIR="$HOME/.local/share/cvm"
 DOWNLOADS_DIR="$CURSOR_DIR/app-images"
-CVM_VERSION="1.1.1"
+CVM_VERSION="1.1.2"
 
 
 
@@ -207,6 +207,27 @@ isShellSupported() {
   esac
 }
 
+cleanupAppImages() {
+  for build_file in "$DOWNLOADS_DIR"/cursor-*-build-*-x86_64.AppImage; do
+    # Skip if no files match the pattern
+    [ -e "$build_file" ] || continue
+    
+    # Extract version number from build file
+    version=$(basename "$build_file" | sed -E 's/cursor-([0-9.]+)-build.*/\1/')
+    regular_file="$DOWNLOADS_DIR/cursor-$version.AppImage"
+    
+    if [ -f "$regular_file" ]; then
+      # If regular version exists, remove build version
+      rm "$build_file"
+      # echo "Removed build version for $version (regular version exists)"
+    else
+      # If only build version exists, rename it to regular format
+      mv "$build_file" "$regular_file"
+      # echo "Renamed build version to regular format for $version"
+    fi
+  done
+}
+
 
 
 #
@@ -222,6 +243,7 @@ fi
 
 checkDependencies
 mkdir -p "$DOWNLOADS_DIR"
+cleanupAppImages
 
 case "$1" in
   --help|-h)


### PR DESCRIPTION
Cursor downloads its own app images in order to be able to self update, which clashes with the script.
```
cursor-0.42.4-build-2410291z3bdg1dy-x86_64.AppImage
```

To resolve that the changes in this PR rename and deduplicate the AppImages, so the automatically downloaded ones can be used by the script.